### PR TITLE
Various fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,8 +32,8 @@ function App() {
   const join = async (appId: string) => {
     if (!appId) return;
     const res = await startSession({ appId }).unwrap();
-    const primaryUrl = res.csLanUrl || res.url;
-    const fallbackUrl = res.csLanUrl ? res.url : undefined;
+    const primaryUrl = res.fallbackUrl || res.url;
+    const fallbackUrl = res.fallbackUrl ? res.url : undefined;
     console.log("Joining debug session at " + primaryUrl + (fallbackUrl ? " (fallback: " + fallbackUrl + ")" : ""));
     dispatch({ type: WS_CONNECT, payload: { url: primaryUrl, fallbackUrl } });
   };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,8 +32,10 @@ function App() {
   const join = async (appId: string) => {
     if (!appId) return;
     const res = await startSession({ appId }).unwrap();
-    console.log("Joining debug session at " + res.url);
-    dispatch({ type: WS_CONNECT, payload: { url: res.url } });
+    const primaryUrl = res.csLanUrl || res.url;
+    const fallbackUrl = res.csLanUrl ? res.url : undefined;
+    console.log("Joining debug session at " + primaryUrl + (fallbackUrl ? " (fallback: " + fallbackUrl + ")" : ""));
+    dispatch({ type: WS_CONNECT, payload: { url: primaryUrl, fallbackUrl } });
   };
 
   const stop = (appId: string) => {

--- a/src/features/DebugConsole/DebugConsole.tsx
+++ b/src/features/DebugConsole/DebugConsole.tsx
@@ -25,10 +25,10 @@ const DebugConsole = ({isConnected, join, stop, clear}: DebugConsoleProps) => {
   const { appId } = useAppParams();
   const dispatch = useAppDispatch();
   const messages = useAppSelector((state: RootState) => state.websocket.messages);
-  const failedUrl = useAppSelector((state: RootState) => state.websocket.failedUrl);
+  const failedUrls = useAppSelector((state: RootState) => state.websocket.failedUrls);
   const searchText = useAppSelector(selectSearchText);
-  const certUrl = failedUrl
-    ? new URL(failedUrl).origin.replace(/^wss:/, 'https:').replace(/^ws:/, 'http:')
+  const certUrls = failedUrls
+    ? failedUrls.map((u: string) => new URL(u).origin.replace(/^wss:/, 'https:').replace(/^ws:/, 'http:'))
     : null;
 
   const { data: doNotLoadConfigOnNextBoot } =
@@ -140,12 +140,17 @@ const DebugConsole = ({isConnected, join, stop, clear}: DebugConsoleProps) => {
           </Button>
           <span className="ps-2">Message Count: {messages.length}</span>
         </div>
-        {certUrl && (
+        {certUrls && certUrls.length > 0 && (
           <Alert variant="warning" className="py-2 px-3 mb-2" style={{ fontSize: '0.82rem' }}>
             <strong>Connection failed.</strong> The debug server may have an untrusted certificate.{' '}
-            <Alert.Link href={certUrl} target="_blank" rel="noreferrer">
-              Open {certUrl} in a new tab
-            </Alert.Link>
+            {certUrls.map((certUrl: string, i: number) => (
+              <span key={certUrl}>
+                {i > 0 && ' or '}
+                <Alert.Link href={certUrl} target="_blank" rel="noreferrer">
+                  Open {certUrl} in a new tab
+                </Alert.Link>
+              </span>
+            ))}
             {', accept the certificate, then try "Start Debug Session" again.'}
           </Alert>
         )}

--- a/src/store/apiSlice.ts
+++ b/src/store/apiSlice.ts
@@ -388,6 +388,7 @@ interface MethodParam {
 
 interface DebugSession {
   url: string;
+  csLanUrl: string;
 }
 
 export interface MobileControlClient {

--- a/src/store/apiSlice.ts
+++ b/src/store/apiSlice.ts
@@ -388,7 +388,7 @@ interface MethodParam {
 
 interface DebugSession {
   url: string;
-  csLanUrl: string;
+  fallbackUrl?: string;
 }
 
 export interface MobileControlClient {

--- a/src/store/websocketMiddleware.ts
+++ b/src/store/websocketMiddleware.ts
@@ -42,7 +42,11 @@ export const websocketMiddleware: Middleware = (store) => {
             console.log("[ws] Primary connection failed, falling back to", fallback);
             connectToUrl(fallback);
           } else {
-            store.dispatch(connectionFailed(targetUrl));
+            // Report all attempted URLs (primary + fallback that was tried)
+            const attemptedUrls = fallbackUrl && targetUrl === fallbackUrl
+              ? [url, fallbackUrl]
+              : [targetUrl];
+            store.dispatch(connectionFailed(attemptedUrls));
           }
         };
         socket.onmessage = (event: MessageEvent<string>) => {

--- a/src/store/websocketMiddleware.ts
+++ b/src/store/websocketMiddleware.ts
@@ -18,7 +18,7 @@ export const websocketMiddleware: Middleware = (store) => {
     const { type } = action as WsConnectAction | WsDisconnectAction;
 
     if (type === WS_CONNECT) {
-      const { url } = (action as WsConnectAction).payload;
+      const { url, fallbackUrl } = (action as WsConnectAction).payload;
 
       console.log("[ws] Connecting to", url);
 
@@ -29,23 +29,32 @@ export const websocketMiddleware: Middleware = (store) => {
         socket.close();
       }
 
-      socket = new WebSocket(url);
-      socket.onopen = () => store.dispatch(connected());
-      socket.onclose = () => {
-        store.dispatch(disconnected());
-        socket = null;
+      const connectToUrl = (targetUrl: string, fallback?: string) => {
+        socket = new WebSocket(targetUrl);
+        socket.onopen = () => store.dispatch(connected());
+        socket.onclose = () => {
+          store.dispatch(disconnected());
+          socket = null;
+        };
+        socket.onerror = (err) => {
+          console.error("WebSocket error", err);
+          if (fallback) {
+            console.log("[ws] Primary connection failed, falling back to", fallback);
+            connectToUrl(fallback);
+          } else {
+            store.dispatch(connectionFailed(targetUrl));
+          }
+        };
+        socket.onmessage = (event: MessageEvent<string>) => {
+          try {
+            store.dispatch(messageReceived(JSON.parse(event.data)));
+          } catch (e) {
+            console.error("Failed to parse WebSocket message", e);
+          }
+        };
       };
-      socket.onerror = (err) => {
-        console.error("WebSocket error", err);
-        store.dispatch(connectionFailed(url));
-      };
-      socket.onmessage = (event: MessageEvent<string>) => {
-        try {
-          store.dispatch(messageReceived(JSON.parse(event.data)));
-        } catch (e) {
-          console.error("Failed to parse WebSocket message", e);
-        }
-      };
+
+      connectToUrl(url, fallbackUrl);
 
       return;
     }

--- a/src/store/websocketSlice.ts
+++ b/src/store/websocketSlice.ts
@@ -57,7 +57,7 @@ export const WS_DISCONNECT = "websocket/disconnect";
 
 export interface WsConnectAction {
   type: typeof WS_CONNECT;
-  payload: { url: string };
+  payload: { url: string; fallbackUrl?: string };
 }
 
 export interface WsDisconnectAction {

--- a/src/store/websocketSlice.ts
+++ b/src/store/websocketSlice.ts
@@ -4,13 +4,13 @@ import { LogMessage } from "../shared/types/LogMessage";
 interface WebsocketState {
   messages: LogMessage[];
   isConnected: boolean;
-  failedUrl: string | null;
+  failedUrls: string[] | null;
 }
 
 const initialState: WebsocketState = {
   messages: [],
   isConnected: false,
-  failedUrl: null,
+  failedUrls: null,
 };
 
 const websocketSlice = createSlice({
@@ -34,12 +34,12 @@ const websocketSlice = createSlice({
       state.messages = [];
     },
     /** Dispatched by the middleware when a connection attempt fails */
-    connectionFailed(state, action: PayloadAction<string>) {
-      state.failedUrl = action.payload;
+    connectionFailed(state, action: PayloadAction<string[]>) {
+      state.failedUrls = action.payload;
     },
     /** Dispatched by the middleware when a new connection attempt starts */
     connectionAttemptStarted(state) {
-      state.failedUrl = null;
+      state.failedUrls = null;
     },
   },
 });


### PR DESCRIPTION
This pull request enhances the application's WebSocket connection logic by adding support for a fallback URL when connecting to a debug session. It also improves error reporting by tracking all failed connection attempts, and updates the UI to inform users about multiple failed certificate URLs that may need to be trusted.

**WebSocket Connection Handling:**

* The `join` function in `App.tsx` now supports a `fallbackUrl` for WebSocket connections, prioritizing `fallbackUrl` if available and passing both URLs to the connection logic. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L35-R38) [[2]](diffhunk://#diff-7c89a1d9581dcb8edf0874387a63059e0929a81d1910ee65d885bed9e0da5de4R391)
* The WebSocket middleware (`websocketMiddleware.ts`) has been refactored to attempt connecting to the primary URL first, and automatically fall back to the secondary URL if the primary fails. All attempted URLs are reported on failure. [[1]](diffhunk://#diff-0ba94b933eb119b04c3662a6e266221cef96f46053f71660a194cee029871492L21-R21) [[2]](diffhunk://#diff-0ba94b933eb119b04c3662a6e266221cef96f46053f71660a194cee029871492L32-R50) [[3]](diffhunk://#diff-0ba94b933eb119b04c3662a6e266221cef96f46053f71660a194cee029871492R59-R61)

**Error Reporting and State Management:**

* The Redux state now tracks an array of failed URLs (`failedUrls`) instead of a single URL, allowing the UI to display all failed connection attempts. [[1]](diffhunk://#diff-74623bb766b19b8ab27682fe46727d9a601284016ea278b529f9e0fb12745fe0L7-R13) [[2]](diffhunk://#diff-74623bb766b19b8ab27682fe46727d9a601284016ea278b529f9e0fb12745fe0L37-R42) [[3]](diffhunk://#diff-74623bb766b19b8ab27682fe46727d9a601284016ea278b529f9e0fb12745fe0L60-R60)

**User Interface Improvements:**

* The `DebugConsole` component now displays all URLs with failed certificate connections, providing users with direct links to accept certificates for each failed attempt. [[1]](diffhunk://#diff-906883cd70bf2e51b7654782dbddef88bfbdce37793dc8bbbcca304786e603ebL28-R31) [[2]](diffhunk://#diff-906883cd70bf2e51b7654782dbddef88bfbdce37793dc8bbbcca304786e603ebL143-R153)